### PR TITLE
refactor: 질문 생성시 새로운 데이터로 다시 랜더링되게 구현

### DIFF
--- a/src/components/common/Editor.jsx
+++ b/src/components/common/Editor.jsx
@@ -27,7 +27,7 @@ const TextArea = styled.textarea`
   border: none;
 `;
 
-const Editor = ({ placeholder, width, height, ModalClose }) => {
+const Editor = ({ placeholder, width, height, ModalClose, setPostData }) => {
   const [question, setQuestion] = useState('');
   const { postId } = useParams();
 
@@ -36,7 +36,15 @@ const Editor = ({ placeholder, width, height, ModalClose }) => {
   };
 
   const handlePostQuestion = () => {
-    createquestion(postId, question);
+    createquestion(postId, question)
+      .then(res => {
+        // 질문을 생성하고 새로운 데이터로 업데이트
+        setPostData(prev => [res, ...prev]);
+      })
+      .catch(error => {
+        // 오류 처리
+        console.error('질문을 생성하는데 문제가 생겼습니다.', error);
+      });
     setQuestion('');
     ModalClose();
   };

--- a/src/components/list/Filter.jsx
+++ b/src/components/list/Filter.jsx
@@ -90,15 +90,20 @@ const Option = styled.li`
 
 function Filter() {
   // 드롭다운(필터) 옵션, 기본 선택은 최신순(createdAt)
-  const [filter, setFilter] = useState('createdAt');
+  const [searchsort] = useSearchParams();
   const [searchPage] = useSearchParams();
+  const sort = searchsort.get('sort');
+  const page = searchPage.get('page');
+
+  const [filter, setFilter] = useState(sort);
   // 드롭다운 메뉴의 표시, 기본 false 상태로 숨겨져 있음
   const [isShow, setIsShow] = useState(false);
   // 드롭다운 메뉴에서 현재 포커스된 옵션의 인덱스
   const [focusedOptionIndex, setFocusedOptionIndex] = useState(1);
+
   const ref = useRef(null);
   const navigate = useNavigate();
-  const page = searchPage.get('page');
+
   const options = ['createdAt', 'name'];
 
   // 요구사항에는 없지만, 드롭다운 메뉴밖 영역을 선택했을때 드롭다운 메뉴 표시가 꺼지도록 설정

--- a/src/components/post/PostBanner.jsx
+++ b/src/components/post/PostBanner.jsx
@@ -56,7 +56,7 @@ const PostUserName = styled.div`
 const PostBanner = ({ userProfileImage, userName }) => {
   return (
     <BannerContainer>
-      <Link to="/list">
+      <Link to="/list?page=1&sort=createdAt">
         <PostLogo />
       </Link>
       <PostAvatar imageSrc={userProfileImage} />

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -1,19 +1,9 @@
 import PostItem from './PostItem';
 import NoQuestion from './NoQuestion';
-import { useEffect, useState } from 'react';
-import { getQuestionsById } from '../../api';
 import { useParams } from 'react-router-dom';
 
-const PostList = () => {
+const PostList = ({ postData, setPostData }) => {
   const { postId } = useParams();
-  const [postData, setPostData] = useState([]);
-
-  useEffect(() => {
-    getQuestionsById(postId).then(res => {
-      const { results } = res;
-      setPostData(() => results);
-    });
-  }, [postId]);
 
   // postData.results는 해당 Post 페이지 내에 존재하는 질문들을 담은 배열입니다.
   if (!postData) return <></>;
@@ -24,7 +14,6 @@ const PostList = () => {
       <PostItem
         key={item.id}
         qnaData={item}
-        {...item}
         setPostData={setPostData}
         postId={postId}
       />

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -59,7 +59,6 @@ const Feed = styled.div`
 const Post = () => {
   const [shortUI, setShortUI] = useState(false);
   const [postData, setPostData] = useState([]);
-  console.log(postData);
 
   const { currentSubject, setCurrentSubject } = useSubject();
   // 모달 오픈 여부 변수

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PostBanner from 'components/post/PostBanner';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { deleteSubject, getSubjectById } from '../api';
+import { deleteSubject, getQuestionsById, getSubjectById } from '../api';
 import Share from 'components/post/Share';
 import Button from 'components/common/Button';
 import styled from 'styled-components';
@@ -57,21 +57,18 @@ const Feed = styled.div`
 `;
 
 const Post = () => {
-  const { postId } = useParams();
-
-  // const [userData, setUserData] = useState();
   const [shortUI, setShortUI] = useState(false);
-  const { currentSubject, setCurrentSubject } = useSubject();
+  const [postData, setPostData] = useState([]);
+  console.log(postData);
 
+  const { currentSubject, setCurrentSubject } = useSubject();
   // 모달 오픈 여부 변수
   const { openModal, handleModalOpen, handleModalClose } = useModal();
-
+  const { postId } = useParams();
   const { pathname } = useLocation();
   const paths = pathname.split('/');
   const isAnswerPage = paths[paths.length - 1] === 'answer';
-
   const { windowWidth } = useBrowserSize();
-
   const navigate = useNavigate();
 
   const handleUIsize = useCallback(() => {
@@ -96,6 +93,13 @@ const Post = () => {
   useEffect(() => {
     handleUIsize();
   }, [handleUIsize]);
+
+  useEffect(() => {
+    getQuestionsById(postId).then(res => {
+      const { results } = res;
+      setPostData(() => results);
+    });
+  }, [postId]);
 
   if (!currentSubject) return <></>;
 
@@ -123,6 +127,7 @@ const Post = () => {
             width={shortUI ? 279 : 530}
             height={shortUI ? 358 : 180}
             ModalClose={handleModalClose}
+            setPostData={setPostData}
           />
         </ModalContainer>
       )}
@@ -146,7 +151,7 @@ const Post = () => {
         )}
         <Feed>
           <PostCount questionCount={currentSubject.questionCount} />
-          <PostList />
+          <PostList postData={postData} setPostData={setPostData} />
         </Feed>
         {!isAnswerPage && (
           <StyledButtonDiv>


### PR DESCRIPTION
## 작업 내용

- PostList에서 관리하던 postData 변수를 Post 컴포넌트로 가져오고, 새로운 질문이 작성되면 postData가 서버측에서 다시 받아온 데이터를 가지고 다시 랜러딩될 수 있게 구현하였습니다.

- List 페이지에서 새로고침시  filter 상태와 URL 상태가 서로 일치하도록 코드 수정
