### PR TITLE
404 페이지 구현 및 데이터 null일 경우 처리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import GlobalStyle from 'GlobalStyle';
 import List from 'pages/List';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Post from 'pages/Post';
+import NotFound from 'pages/NotFound';
 import { SubjectProvider } from 'context/subjectContext';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
             <Route path="/list" element={<List />} />
             <Route path="/post/:postId" element={<Post />} />
             <Route path="/post/:postId/answer" element={<Post />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>
       </SubjectProvider>

--- a/src/components/common/ModalProfileList.jsx
+++ b/src/components/common/ModalProfileList.jsx
@@ -33,10 +33,12 @@ const ModalProfileList = () => {
   const userInfo = localStorage.getItem('user');
   const parsedInfo = JSON.parse(userInfo);
 
-  const userArray = Object.entries(parsedInfo).map(([id, name]) => ({
-    id: id,
-    name: name,
-  }));
+  const userArray =
+    parsedInfo &&
+    Object.entries(parsedInfo).map(([id, name]) => ({
+      id: id,
+      name: name,
+    }));
 
   if (!parsedInfo) {
     return (

--- a/src/components/list/CardList.jsx
+++ b/src/components/list/CardList.jsx
@@ -83,8 +83,10 @@ const CardList = () => {
     );
 
   if (
-    location.search.split('&').at(-1) !== 'sort=createdAt' &&
-    location.search.split('&').at(-1) !== 'sort=name'
+    location.search !== '' &&
+    location.search.split('=').at(-1) !== 'createdAt' &&
+    location.search.split('=').at(-1) !== 'name' &&
+    location.search.split('=').at(-1) !== 'null'
   )
     return <Navigate to="/src/pages/NotFound" />;
 

--- a/src/components/list/CardList.jsx
+++ b/src/components/list/CardList.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import CardItem from './CardItem';
 import PagiNation from './PagiNation';
 import { getAllSubject } from 'api';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useLocation, useSearchParams } from 'react-router-dom';
 import useBrowserSize from 'hooks/useBrowserSize';
 import Loding from 'components/common/Loding';
 
@@ -29,6 +29,8 @@ const CardList = () => {
   const [cards, setCards] = useState(null);
   const [limit, setLimit] = useState(8);
   const [isLoading, setIsLoading] = useState(false);
+
+  const location = useLocation();
 
   const [searchPage] = useSearchParams();
   const [searchSort] = useSearchParams();
@@ -79,6 +81,12 @@ const CardList = () => {
         <Loding />
       </>
     );
+
+  if (
+    location.search.split('&').at(-1) !== 'sort=createdAt' &&
+    location.search.split('&').at(-1) !== 'sort=name'
+  )
+    return <Navigate to="/src/pages/NotFound" />;
 
   return (
     <>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,80 @@
+import Button from 'components/common/Button';
+import LogoBox from '../components/common/LogoBox.jsx';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+const WarnMessage = styled.h1`
+  color: var(--gray50);
+  font-size: 40px;
+  font-weight: 600;
+  font-family: Pretsendard;
+`;
+
+const Description = styled.p`
+  color: var(--gray60);
+  font-size: 24px;
+  font-weight: 400;
+  font-family: Pretendard;
+`;
+
+const SubDescription = styled(Description)`
+  font-size: 18px;
+`;
+
+const MainLogo = styled(LogoBox)`
+  display: flex;
+  justify-content: center;
+  padding-top: 20px;
+  padding-bottom: 40px;
+  margin: auto;
+  width: 314px;
+
+  @media (max-width: 767px) {
+    width: 248px;
+  }
+`;
+
+const ToHome = styled(Link)`
+  color: var(--brown40);
+  font-size: 18px;
+  font-weight: 400;
+  font-family: Pretendard;
+`;
+
+const NotFound = () => {
+  return (
+    <Container>
+      <Content>
+        <WarnMessage>404 ERROR</WarnMessage>
+        <Description>
+          죄송합니다. 요청하신 페이지를 찾을 수 없습니다.
+        </Description>
+        <SubDescription>
+          입력하신 주소가 맞는지 다시 확인해 주세요.
+        </SubDescription>
+        <MainLogo />
+        <ToHome to="/">
+          <Button width={160} bright={true}>
+            홈으로 돌아가기
+          </Button>
+        </ToHome>
+      </Content>
+    </Container>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## 작업 내용

- 404 페이지(NotFound) 구현
- 잘못된 경로 입력 시 404 페이지로 이동되도록 구현
- ModalProfileList 파일에서 데이터 읽어올 때 null 일때의 처리

## 스크린샷

<img width="1461" alt="image" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/80617716/1a8213da-3125-438e-9b5a-05982c09fc36">

## 참고 사항

- 카드아이템에서 경로에 '/answer' 적으면 해당 answer 페이지로 이동되는거 막아야 하는데, 아직 못했습니다.
