### PR TITLE
Post페이지에서 경로에 '/answer' 적으면 해당 answer 페이지로 이동되는거 막음 - odd

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import List from 'pages/List';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Post from 'pages/Post';
 import { SubjectProvider } from 'context/subjectContext';
+import AnswerProtectedRoute from 'components/post/AnswerProtectedRoute';
 
 function App() {
   return (
@@ -15,7 +16,10 @@ function App() {
             <Route path="/" element={<Main />} />
             <Route path="/list" element={<List />} />
             <Route path="/post/:postId" element={<Post />} />
-            <Route path="/post/:postId/answer" element={<Post />} />
+            <Route
+              path="/post/:postId/answer"
+              element={<AnswerProtectedRoute />}
+            />
           </Routes>
         </BrowserRouter>
       </SubjectProvider>

--- a/src/components/post/AnswerProtectedRoute.jsx
+++ b/src/components/post/AnswerProtectedRoute.jsx
@@ -1,0 +1,29 @@
+import { useParams } from 'react-router-dom';
+import NotFound from 'pages/NotFound';
+import Post from 'pages/Post';
+
+// 사용자의 게시물 접근 권한을 검사
+const checkAccessToPost = postId => {
+  // 로컬 스토리지에서 'user' 객체를 가져옴
+  const user = JSON.parse(localStorage.getItem('user')) || {};
+
+  // 현재 페이지의 postId가 로컬 스토리지에 저장된 게시물 ID와 일치하는지 확인
+  // Object.keys(user)를 사용하여 모든 게시물 ID를 배열로 가져온 후, 현재 페이지의 postId가 이 배열에 포함되어 있는지 확인
+  const hasAccess = Object.keys(user).includes(postId);
+
+  return hasAccess;
+};
+
+const AnswerProtectedRoute = () => {
+  const { postId } = useParams();
+  const hasAccess = checkAccessToPost(postId);
+
+  // 접근 권한이 없으면 NotFound 페이지를 렌더링합니다.
+  if (!hasAccess) {
+    return <NotFound />;
+  }
+
+  return <Post />;
+};
+
+export default AnswerProtectedRoute;


### PR DESCRIPTION
## 작업 내용

- Post페이지에서 주소창에 /answer 입력했을 경우, 내 로컬스토리지에 저장된 id의 Post가 아닌 경우 NotFound 페이지로 연결

## 스크린샷
### NotFound페이지 연결전
<img width="641" alt="스크린샷 2024-03-07 오후 9 31 18" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/f2c5292a-d77a-4e84-a024-82ea5c1819dd">

### NotFound페이지 연결후
<img width="521" alt="스크린샷 2024-03-07 오후 9 30 22" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/8355d516-69aa-439d-b896-ddb91fb40d67">
