### PR TITLE
Odd

### DIFF
--- a/src/components/post/AnswerInputForm.jsx
+++ b/src/components/post/AnswerInputForm.jsx
@@ -1,7 +1,7 @@
 // 답변을 생성하고 수정하는 input 컴포넌트
 import styled from 'styled-components';
 import Button from 'components/common/Button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createAnswer, editAnswer } from 'api';
 
 const Container = styled.div`
@@ -39,12 +39,20 @@ const AnswerInputForm = ({
   placeholder,
   children,
   questionId,
+  originalAnswer = '',
   buttonText,
   type,
   answerId,
   onEditCancel,
 }) => {
-  const [answer, setAnswer] = useState('');
+  // children prop이 전달되면 답변 수정상황으로 판단하여, children을 초기상태로 사용
+  // 그렇지 않다면 답변 생성상황으로 판단하여, 빈 문자열을 초기 상태로 사용
+  const [answer, setAnswer] = useState(children || '');
+
+  // children prop이 변경될 때마다 answer 상태를 업데이트(답변 수정 시 초기 값이 원본 답변으로 설정되도록 함)
+  useEffect(() => {
+    setAnswer(children || '');
+  }, [children]);
 
   const handleChange = e => {
     setAnswer(e.target.value);
@@ -58,16 +66,24 @@ const AnswerInputForm = ({
     editAnswer(answerId, answer).then(() => window.location.reload());
   };
 
+  // 원본 답변과 현재 답변이 동일한지 여부를 체크
+  const isAnswerUnchanged = originalAnswer.trim() === answer.trim();
+
   return (
     <Container>
-      <StyledTextArea placeholder={placeholder} onChange={handleChange}>
+      <StyledTextArea
+        placeholder={placeholder}
+        value={answer}
+        onChange={handleChange}
+      >
         {children}
       </StyledTextArea>
       {/*답변을 생성하는 input인 경우 '답변 완료' 버튼 하나, 답변을 수정하는 input인 경우 '수정완료' '수정취소' 두개의 버튼이 나타납니다.*/}
       {/*답변을 생성하는 input인 경우 handleCreateAnswer, 답변을 수정하는 input인 경우 handleEditAnswer 함수를 실행합니다.*/}
       <ButtonContainer>
         <Button
-          inactive={answer.trim() === ''}
+          // 답변이 비어있거나 변경되지 않았을 때 '수정 완료'버튼 비활성화
+          inactive={answer.trim() === '' || isAnswerUnchanged}
           onClick={
             type === 'create answer' ? handleCreateAnswer : handleEditAnswer
           }

--- a/src/components/post/Kebab.jsx
+++ b/src/components/post/Kebab.jsx
@@ -62,10 +62,22 @@ const Kebab = ({
         {isClicked && (
           <KebabOptions
             isClick={isClicked}
-            onEditClick={onEditClick}
-            onDeleteQuestionClick={onDeleteQuestionClick}
-            onDeleteAnswerClick={onDeleteAnswerClick}
-            onRejectClick={onRejectClick}
+            onEditClick={() => {
+              onEditClick();
+              setIsClicked(false);
+            }}
+            onDeleteQuestionClick={() => {
+              onDeleteQuestionClick();
+              setIsClicked(false);
+            }}
+            onDeleteAnswerClick={() => {
+              onDeleteAnswerClick();
+              setIsClicked(false);
+            }}
+            onRejectClick={() => {
+              onRejectClick();
+              setIsClicked(false);
+            }}
           />
         )}
       </>

--- a/src/components/post/Kebab.jsx
+++ b/src/components/post/Kebab.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as Icons from 'components/common/Icons';
 import Button from 'components/common/Button';
 import KebabOptions from 'components/post/KebabOptions';
@@ -31,13 +31,29 @@ const Kebab = ({
   onRejectClick,
 }) => {
   const [isClicked, setIsClicked] = useState(false);
+  const ref = useRef(null); // 컨테이너에 대한 참조를 생성
 
   const handleToggle = () => {
     setIsClicked(!isClicked);
   };
 
+  // 케밥 영역 바깥을 선택했을때 케밥옵션 메뉴 표시가 꺼지도록 설정
+  useEffect(() => {
+    function handleClickOutside(event) {
+      // 클릭된 요소가 케밥 영역 바깥이라면 케밥의 옵션을 닫음
+      if (ref.current && !ref.current.contains(event.target)) {
+        setIsClicked(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
   return (
-    <Container>
+    <Container ref={ref}>
       <KebabButton varient="icon" onClick={handleToggle}>
         <Icons.Kebab />
       </KebabButton>

--- a/src/components/post/QuestionContent.jsx
+++ b/src/components/post/QuestionContent.jsx
@@ -60,10 +60,12 @@ const QuestionContent = ({
         />
       ) : type === 'edit answer' ? (
         // 답변 수정일 경우에 input을 렌더링 하며, API 호출시 필요한 answerId, 수정모드인지 아닌지 상태, 수정 취소 시 실행할 함수를 추가적으로 보내줍니다.
+        // originalAnswer={textContents} -> 원본 답변 내용을 prop으로 전달
         <AnswerInputForm
           buttonText="수정 완료"
           type={type}
           answerId={answerId}
+          originalAnswer={textContents}
           isEdit={isEdit}
           onEditCancel={onEditCancel}
         >


### PR DESCRIPTION
## 작업 내용

- answer에서 답변내용이 실제로 수정되지 않았을 때, '수정 완료'버튼이 비활성화 되도록 수정
- KebabOption이 열려있는 상태에서, 바깥 영역을 클릭하면 KebabOptions 닫히도록 수정
- KebabOption을 선택한 뒤에, KebabOption이 닫히지 않던 이슈 해결

## 스크린샷
###  answer에서 답변내용이 실제로 수정되지 않았을 때, '수정 완료'버튼이 활성화되던 현상
<img width="666" alt="스크린샷 2024-03-08 오후 2 03 43" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/d98904ba-6758-4606-a7aa-9628c908fbc1">

###  answer에서 답변내용이 실제로 수정되지 않았을 때, '수정 완료'버튼 비활성화
<img width="679" alt="스크린샷 2024-03-08 오후 2 02 09" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/8a8ffebd-feb2-4301-b065-470bfd88c772">

###  KebabOption이 열려있는 상태에서, 바깥 영역을 클릭해도 KebabOption이 닫히지 않던 현상 & KebabOption을 선택한 뒤에, KebabOption이 닫히지 않던 현상
<img width="681" alt="스크린샷 2024-03-08 오후 2 17 19" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/e397411c-ab46-483e-9d4c-b91b0919bb07">

###  KebabOption이 열려있는 상태에서, 바깥 영역을 클릭하면 KebabOption이 닫히도록 수정 & KebabOption을 선택한 뒤에, KebabOption이 닫히도록 수정
<img width="641" alt="스크린샷 2024-03-08 오후 2 25 40" src="https://github.com/78-artilleryman/Codeit-8team-OpenMind/assets/142493319/01982122-d178-4125-8b92-9b45964e592b">